### PR TITLE
Assert that a callable throws an exception

### DIFF
--- a/src/ClassTest/AbstractTestCase.php
+++ b/src/ClassTest/AbstractTestCase.php
@@ -152,4 +152,31 @@ abstract class AbstractTestCase extends TestCase
 
         return $dummy;
     }
+
+    /**
+     * @param callable $callable
+     * @param string $exceptionClass
+     * @param int $exceptionCode
+     * @param string $exceptionMessage
+     */
+    protected function assertCallableThrowsException(callable $callable, $exceptionClass, $exceptionCode = null, $exceptionMessage = null)
+    {
+        try {
+            $callable();
+        } catch (\Exception $exception) {
+            $this->assertInstanceOf($exceptionClass, $exception);
+
+            if ($exceptionCode !== null) {
+                $this->assertEquals($exceptionCode, $exception->getCode());
+            }
+
+            if ($exceptionMessage !== null) {
+                $this->assertContains($exceptionMessage, $exception->getMessage());
+            }
+
+            return;
+        }
+
+        $this->fail('Expected ' . $exceptionClass . ' but no exception was thrown');
+    }
 }

--- a/src/ClassTest/AbstractTestCase.php
+++ b/src/ClassTest/AbstractTestCase.php
@@ -152,31 +152,4 @@ abstract class AbstractTestCase extends TestCase
 
         return $dummy;
     }
-
-    /**
-     * @param callable $callable
-     * @param string $exceptionClass
-     * @param int $exceptionCode
-     * @param string $exceptionMessage
-     */
-    protected function assertCallableThrowsException(callable $callable, $exceptionClass, $exceptionCode = null, $exceptionMessage = null)
-    {
-        try {
-            $callable();
-        } catch (\Exception $exception) {
-            $this->assertInstanceOf($exceptionClass, $exception);
-
-            if ($exceptionCode !== null) {
-                $this->assertEquals($exceptionCode, $exception->getCode());
-            }
-
-            if ($exceptionMessage !== null) {
-                $this->assertContains($exceptionMessage, $exception->getMessage());
-            }
-
-            return;
-        }
-
-        $this->fail('Expected ' . $exceptionClass . ' but no exception was thrown');
-    }
 }

--- a/src/TestTools.php
+++ b/src/TestTools.php
@@ -6,6 +6,7 @@ use ClassTest\Exception\NotProphesizableException;
 use Prophecy\Argument;
 use Prophecy\Prophecy\MethodProphecy;
 use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework\Assert;
 
 /**
  * Class TestTools
@@ -130,5 +131,34 @@ class TestTools
         } catch (\ReflectionException $exception) {
             throw new NotProphesizableException();
         }
+    }
+
+    /**
+     * Allow multiple exception assertions within one test using a callable
+     *
+     * @param callable $callable
+     * @param string $exceptionClass
+     * @param int $exceptionCode
+     * @param string $exceptionMessage
+     */
+    public static function assertCallableThrowsException(callable $callable, $exceptionClass, $exceptionCode = null, $exceptionMessage = null)
+    {
+        try {
+            $callable();
+        } catch (\Exception $exception) {
+            Assert::assertInstanceOf($exceptionClass, $exception);
+
+            if ($exceptionCode !== null) {
+                Assert::assertEquals($exceptionCode, $exception->getCode());
+            }
+
+            if ($exceptionMessage !== null) {
+                Assert::assertContains($exceptionMessage, $exception->getMessage());
+            }
+
+            return;
+        }
+
+        Assert::fail('Expected ' . $exceptionClass . ' but no exception was thrown');
     }
 }


### PR DESCRIPTION
* Allows multiple exception assertions within one test

**Example**
```php
public function fooTest()
{
    $foo = new Foo();
    $callableBar = function () use ($foo) {
        $foo->getBar();
    };
    $callableBaz = function () use ($foo) {
        $foo->getBaz();
    };
    $this->assertCallableThrowsException($callableBar, \RuntimeException::class);
    $this->assertCallableThrowsException($callableBaz, \LogicException::class);
}
```