### PR TITLE
Support void methods

### DIFF
--- a/src/TestTools.php
+++ b/src/TestTools.php
@@ -75,8 +75,10 @@ class TestTools
             $methodProphecy = array_shift($methodProphecies);
         }
 
-        $methodProphecy->withArguments(new Argument\ArgumentsWildcard([$arguments]))
-            ->willReturn($return);
+        $methodProphecy->withArguments(new Argument\ArgumentsWildcard([$arguments]);
+        if (!$methodProphecy->hasReturnVoid()) {
+            $methodProphecy->willReturn($return);
+        }
 
         return $methodProphecy;
     }
@@ -86,6 +88,7 @@ class TestTools
      *
      * @param ObjectProphecy $prophecy
      * @param                $prophecyName
+     * @throws
      */
     public static function setDummyProphecy(ObjectProphecy $prophecy, $prophecyName)
     {


### PR DESCRIPTION
## Issue
This PR fixes an issue when one of the class constructor parameters contains a void method.

When parameters are made into dummies (see `prophesizeDummy`), all their methods are prophecized  (see `setDummyProphecy`). All methods are prophecized to return something (null by default) regardless of their void return type.

## Use case
**Bar.php**
```php
class Bar
{
    public function doBaz(): void
    {
        // do something
    }
}
```
**Foo.php**
```php
class Foo
{
    public function __construct(Bar $bar)
    {
        $this->bar = $bar;
    }

    public function doQux(): bool
    {
        $this->bar->doBaz();
        return true;
    }
}
```
**FooTest.php**
```php
class FooTest extends ClassTestCase
{
    protected function getTestedClassName()
    {
        return Foo::class;
    }

    protected function getTestedClassConstructorParameters()
    {
        return [
            Bar::class,
        ];
    }

    public function testItWillTestSomething()
    {
        $foo = $this->getTestedClass();
        $foo->doQux();

        $this->getProphecy(Bar::class, 'doBaz')->shouldHaveBeenCalled();
    }
}
```
### Expected result
OK (1 tests, 1 assertions)

### Current result
Prophecy\Exception\Prophecy\MethodProphecyException: The method "doBaz" has a void return type, and so cannot return anything