### PR TITLE
Replace deprecated prophesized method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require": {
         "php": "^7.1",
-        "phpunit/phpunit": "^7.5|^8.5|^9.5"
+        "phpunit/phpunit": "^9.1",
+        "phpspec/prophecy-phpunit": "^2.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.3 || ^8",
         "phpunit/phpunit": "^9.1",
         "phpspec/prophecy-phpunit": "^2.0"
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,17 +14,15 @@
          timeoutForLargeTests="10"
          bootstrap="vendor/autoload.php"
 >
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
 
-    <testsuites>
-        <testsuite name="ClassTest test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
-
+  <testsuites>
+    <testsuite name="ClassTest test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/ClassTest/AbstractTestCase.php
+++ b/src/ClassTest/AbstractTestCase.php
@@ -7,6 +7,7 @@ namespace ClassTest\ClassTest;
 use ClassTest\Exception\ProphesizedObjectNotFoundException;
 use ClassTest\TestTools;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\MethodProphecy;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophecy\ProphecyInterface;
@@ -18,6 +19,8 @@ use Prophecy\Prophecy\ProphecyInterface;
  */
 abstract class AbstractTestCase extends TestCase
 {
+    use ProphecyTrait;
+
     const DEFAULT_PROPHECY = 0;
 
     const DUMMY_PROPHECY   = 1;
@@ -72,12 +75,12 @@ abstract class AbstractTestCase extends TestCase
      *
      * Methods behavior can still be changed later on, though.
      *
-     * @param string $classOrInterface
+     * @param string|null $classOrInterface
      * @param int $prophecyDummyType
      * @return ObjectProphecy
      * @throws \ReflectionException
      */
-    protected function prophesize($classOrInterface = null, int $prophecyDummyType = self::DEFAULT_PROPHECY): ObjectProphecy
+    protected function prophesize(?string $classOrInterface = null, int $prophecyDummyType = self::DEFAULT_PROPHECY): ObjectProphecy
     {
         return $prophecyDummyType === self::DUMMY_PROPHECY ? parent::prophesize($classOrInterface) : $this->prophesizeDummy(
             $classOrInterface

--- a/src/ClassTest/AbstractTestCase.php
+++ b/src/ClassTest/AbstractTestCase.php
@@ -19,7 +19,9 @@ use Prophecy\Prophecy\ProphecyInterface;
  */
 abstract class AbstractTestCase extends TestCase
 {
-    use ProphecyTrait;
+    use ProphecyTrait {
+        prophesize as parentProphesize;
+    }
 
     const DEFAULT_PROPHECY = 0;
 
@@ -82,7 +84,7 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function prophesize(?string $classOrInterface = null, int $prophecyDummyType = self::DEFAULT_PROPHECY): ObjectProphecy
     {
-        return $prophecyDummyType === self::DUMMY_PROPHECY ? parent::prophesize($classOrInterface) : $this->prophesizeDummy(
+        return $prophecyDummyType === self::DUMMY_PROPHECY ? $this->parentProphesize($classOrInterface) : $this->prophesizeDummy(
             $classOrInterface
         );
     }
@@ -97,7 +99,7 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function prophesizeDummy(?string $class = null): ObjectProphecy
     {
-        $prophecy = parent::prophesize($class);
+        $prophecy = $this->parentProphesize($class);
         TestTools::setDummyProphecy($prophecy, $class);
 
         return $prophecy;

--- a/tests/ClassTestCaseTest.php
+++ b/tests/ClassTestCaseTest.php
@@ -24,7 +24,7 @@ class ClassTestCaseTest extends TestCase
     {
         $mockClassTestCase = $this->getMockBuilder(SomeClassTestCase::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getTestedClassName', 'getTestedClassConstructorParameters'])
+            ->onlyMethods(['getTestedClassName', 'getTestedClassConstructorParameters'])
             ->getMock();
 
         $mockClassTestCase->method('getTestedClassName')->willReturn(SomeClass::class);


### PR DESCRIPTION
From version 9.1.0, the method TestCase::prophesize is deprecated
https://github.com/sebastianbergmann/phpunit/blob/9.1.0/src/Framework/TestCase.php#L1820

* Require phpunit ^9.1
* Fix AbstractTestCase::prophesize typehint
* Fix outdated phpunit config file

This should likely be version 3.0.0 as we have to drop the support of phpunit ^7.5 and ^8.5