### PR TITLE
Fix prophecy method arguments

### DIFF
--- a/src/TestTools.php
+++ b/src/TestTools.php
@@ -71,7 +71,7 @@ class TestTools
         $return = null
     ): MethodProphecy {
         if ($arguments === null) {
-            $arguments = Argument::cetera();
+            $arguments = [Argument::cetera()];
         }
 
         $methodProphecies = $prophecy->getMethodProphecies($methodName);
@@ -83,7 +83,7 @@ class TestTools
             $methodProphecy = array_shift($methodProphecies);
         }
 
-        $methodProphecy->withArguments(new Argument\ArgumentsWildcard([$arguments]));
+        $methodProphecy->withArguments(new Argument\ArgumentsWildcard($arguments));
         if (!$methodProphecy->hasReturnVoid()) {
             $methodProphecy->willReturn($return);
         }


### PR DESCRIPTION
Prevent prophecy method arguments from being wrapped in an array

Test sample
```php
$prophecy->reveal()->doBar('foo');
TestTools::getProphecyMethod($prophecy, 'doBar', ['foo'])->shouldHaveBeenCalled();
```

Current behavior:
```
Expected exactly 1 calls that match:
  Double\P16->doBar(exact(['foo']))
but none were made.
Recorded `doBar(...)` calls:
  - doBar('foo')
```

Expected behavior:
```
OK
```
