### PR TITLE
[1.x] Fix prophecy method arguments

### DIFF
--- a/src/TestTools.php
+++ b/src/TestTools.php
@@ -63,7 +63,7 @@ class TestTools
     public static function getProphecyMethod(ObjectProphecy $prophecy, $methodName, $arguments = null, $return = null)
     {
         if ($arguments === null) {
-            $arguments = Argument::cetera();
+            $arguments = [Argument::cetera()];
         }
 
         $methodProphecies = $prophecy->getMethodProphecies($methodName);
@@ -75,7 +75,7 @@ class TestTools
             $methodProphecy = array_shift($methodProphecies);
         }
 
-        $methodProphecy->withArguments(new Argument\ArgumentsWildcard([$arguments]));
+        $methodProphecy->withArguments(new Argument\ArgumentsWildcard($arguments));
         if (!$methodProphecy->hasReturnVoid()) {
             $methodProphecy->willReturn($return);
         }


### PR DESCRIPTION
Prevent prophecy method arguments from being wrapped in an array

Test sample
```php
$prophecy->reveal()->doBar('foo');
TestTools::getProphecyMethod($prophecy, 'doBar', ['foo'])->shouldHaveBeenCalled();
```

Current behavior:
```
Expected exactly 1 calls that match:
  Double\P16->doBar(exact(['foo']))
but none were made.
Recorded `doBar(...)` calls:
  - doBar('foo')
```

Expected behavior:
```
OK
```
