### PR TITLE
class-test: PHP 8.4 Support + PHPUnit 10/11/12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3' ]
+        php-versions: [ '8.3', '8.4' ]
 
     steps:
       - uses: actions/checkout@v3
@@ -57,12 +57,6 @@ jobs:
         run: |
           sed -i 's+'$GITHUB_WORKSPACE'+/github/workspace+g' build/reports/phpunit/clover.xml
           sed -i 's+'$GITHUB_WORKSPACE'+/github/workspace+g' build/reports/phpunit/unit.xml
-
-      - name: PHP 8.1 Compatibility
-        run: make php81compatibility
-
-      - name: PHP 8.3 Compatibility
-        run: make php83compatibility
 
       - name: PHP Static Analyze
         run: make analyze

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 ```
 
+## [5.0.0] - 2025-08
+[5.0.0]:  https://github.com/C-Malet/class-test/compare/4.0.0...5.0.0
+### Added
+- Add support of PHP 8.4
+- Add support of PHPUnit 11 & 12
+### Removed
+- Drop support of PHP 8.1 & 8.2
+- Drop support of PHPUnit 9
+### Changed
+- Update CI configs
+- Fix phpstan errors
+
+--- 
+
 ## [4.0.0] - 2023-12
-[4.0.0]: https://github.com/C-Malet/class-test/compare/4.0.0...3.0.1
+[4.0.0]: https://github.com/C-Malet/class-test/compare/3.0.1...4.0.0
 ### Removed
 - Remove PHPCS
 - Drop support of PHP 7.3, 7.4 & 8.0

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-.PHONY: validate install update deps phpcs-check phpcs-fix php81compatibility php83compatibility phpstan analyze tests testdox ci clean
+.PHONY: validate install update deps phpcs-check phpcs-fix phpmin-compatibility phpmax-compatibility phpstan analyze tests testdox ci clean
 
+PHP_VERSION_MIN := 8.3
+PHP_VERSION_MAX := 8.4
 define header =
     @if [ -t 1 ]; then printf "\n\e[37m\e[100m  \e[104m $(1) \e[0m\n"; else printf "\n### $(1)\n"; fi
 endef
@@ -11,7 +13,6 @@ validate:
 
 install:
 	$(call header,Composer Install)
-	@composer global require maglnet/composer-require-checker
 	@composer install
 
 update:
@@ -25,6 +26,7 @@ composer.lock: install
 vendor/bin/php-cs-fixer:
 vendor/bin/phpstan:
 vendor/bin/phpunit:
+vendor/bin/phpcov:
 
 #~ Report directories dependencies
 build/reports/phpunit:
@@ -39,7 +41,7 @@ build/reports/phpstan:
 #~ main commands
 deps: composer.json
 	$(call header,Checking Dependencies)
-	@XDEBUG_MODE=off composer-require-checker check
+	@DEBUG_MODE=off ./vendor/bin/composer-dependency-analyser --config=./ci/composer-dependency-analyser.php # for shadow, unused required dependencies & missing ext-*
 
 phpcs-check: vendor/bin/php-cs-fixer
 	$(call header,Checking Code Style)
@@ -53,13 +55,13 @@ phpcs: vendor/bin/php-cs-fixer build/reports/phpcs
 	$(call header,Checking Code Style)
 	@./vendor/bin/php-cs-fixer check --format=checkstyle > ./build/reports/cs/phpcs.xml
 
-php81compatibility: vendor/bin/phpstan build/reports/phpstan
-	$(call header,Checking PHP 8.1 compatibility)
-	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/php81-compatibility.neon --error-format=checkstyle > ./build/reports/phpstan/php81-compatibility.xml
+phpmin-compatibility: vendor/bin/phpstan build/reports/phpstan
+	$(call header,Checking PHP ${PHP_VERSION_MIN} compatibility)
+	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/phpmin-compatibility.neon --error-format=checkstyle > ./build/reports/phpstan/phpmin-compatibility.xml
 
-php83compatibility: vendor/bin/phpstan build/reports/phpstan
-	$(call header,Checking PHP 8.3 compatibility)
-	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/php83-compatibility.neon --error-format=checkstyle > ./build/reports/phpstan/php83-compatibility.xml
+phpmax-compatibility: vendor/bin/phpstan build/reports/phpstan
+	$(call header,Checking PHP ${PHP_VERSION_MAX} compatibility)
+	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/phpmax-compatibility.neon --error-format=checkstyle > ./build/reports/phpstan/phpmax-compatibility.xml
 
 phpstan: vendor/bin/phpstan build/reports/phpstan
 	$(call header,Running Static Analyze)
@@ -71,14 +73,14 @@ analyze: vendor/bin/phpstan build/reports/phpstan
 
 tests: vendor/bin/phpunit build/reports/phpunit #ci
 	$(call header,Running Unit Tests)
-	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-clover=./build/reports/phpunit/clover.xml --log-junit=./build/reports/phpunit/unit.xml --coverage-php=./build/reports/phpunit/unit.cov --coverage-html=./build/reports/coverage/ --fail-on-warning
+	@XDEBUG_MODE=coverage php ./vendor/bin/phpunit --coverage-clover=./build/reports/phpunit/clover.xml --log-junit=./build/reports/phpunit/unit.xml --coverage-php=./build/reports/phpunit/unit.cov --coverage-html=./build/reports/coverage/ --fail-on-warning
 
 testdox: vendor/bin/phpunit #manual
 	$(call header,Running Unit Tests (Pretty format))
-	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --fail-on-warning --testdox
+	@XDEBUG_MODE=coverage php ./vendor/bin/phpunit --testsuite=unit --fail-on-warning --testdox
 
 clean:
 	$(call header,Cleaning previous build)
 	@if [ "$(shell ls -A ./build)" ]; then rm -rf ./build/*; fi; echo " done"
 
-ci: clean validate deps install phpcs-check tests php81compatibility php83compatibility analyze
+ci: clean validate install deps phpcs-check tests phpmin-compatibility phpmax-compatibility analyze

--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ And update with the following command:
 make update
 ```
 
+Check dependencies:
+```bash
+make deps
+```
+
 NB: For the components, the `composer.lock` file is not committed.
 
 ### Testing & CI (Continuous Integration)
@@ -215,9 +220,9 @@ make phpcs-fix
 ```
 
 #### Static Analysis
-To perform a static analyze of your code (with phpstan, lvl 9 at default), you can use the following command:
+To perform a static analyze of your code (with phpstan, lvl max at default), you can use the following command:
 ```bash
-make phpstan
+make analyze
 ```
 
 To ensure you code still compatible with current supported version at Deezer and futures versions of php, you need to
@@ -225,12 +230,12 @@ run the following commands (both are required for full support):
 
 Minimal supported version:
 ```bash
-make php81compatibility
+make phpmin-compatibility
 ```
 
 Maximal supported version:
 ```bash
-make php83compatibility
+make phpmax-compatibility
 ```
 
 #### CI Simulation

--- a/ci/composer-dependency-analyser.php
+++ b/ci/composer-dependency-analyser.php
@@ -1,0 +1,11 @@
+<?php
+
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+
+$config = new Configuration();
+
+return $config
+    ->addPathToScan(__DIR__ . '/../src', isDev: false)
+    ->addPathToScan(__DIR__ . '/../tests', isDev: true)
+;

--- a/ci/phpmax-compatibility.neon
+++ b/ci/phpmax-compatibility.neon
@@ -3,7 +3,7 @@ includes:
   - ./../vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-  phpVersion: 80300 # PHP 8.3
+  phpVersion: 80400
   level: 0
   paths:
     - ./../src

--- a/ci/phpmin-compatibility.neon
+++ b/ci/phpmin-compatibility.neon
@@ -3,7 +3,7 @@ includes:
   - ./../vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-  phpVersion: 80100 # PHP 8.1 - Current minimal version supported
+  phpVersion: 80300
   level: 0
   paths:
     - ./../src

--- a/composer.json
+++ b/composer.json
@@ -19,21 +19,27 @@
 
     "autoload": {
         "psr-4": {
-            "ClassTest\\": "src/",
+            "ClassTest\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "ClassTest\\Tests\\": "tests/"
         }
     },
 
     "require": {
-        "php": "^8.1",
-        "phpunit/phpunit": "^9.0||^10.0",
+        "php": ">=8.3",
+        "phpunit/phpunit": "^10.0||^11.0||^12.0",
         "phpspec/prophecy": "^1.0",
         "phpspec/prophecy-phpunit": "^2.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.41.1",
-        "phpstan/phpstan": "^1.10.50",
-        "phpstan/phpstan-phpunit": "^1.3.15",
-        "phpunit/phpcov": "^9.0.2"
+        "friendsofphp/php-cs-fixer": "^3.85.1",
+        "phpstan/phpstan": "^2.1.22",
+        "phpstan/phpstan-phpunit": "^2.0.7",
+        "phpstan/phpstan-strict-rules": "^2.0.6",
+        "phpunit/phpcov": "^11.0.1",
+        "shipmonk/composer-dependency-analyser": "^1.8.3"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,9 +1,10 @@
 includes:
-  - vendor/phpstan/phpstan-phpunit/extension.neon
-  - vendor/phpstan/phpstan-phpunit/rules.neon
+  - ./vendor/phpstan/phpstan-phpunit/extension.neon
+  - ./vendor/phpstan/phpstan-phpunit/rules.neon
+  - ./vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:
-  phpVersion: 80100 # PHP 8.1 - Current minimal version supported
+  phpVersion: 80300
   level: max
   paths:
     - ./src
@@ -12,6 +13,8 @@ parameters:
   bootstrapFiles:
     - ./vendor/autoload.php
 
+  treatPhpDocTypesAsCertain: false
+
   ignoreErrors:
     -
       path:    'tests/TestClasses/SomeClassTestCase.php'
@@ -19,3 +22,7 @@ parameters:
     -
       path:    'src/TestTools.php'
       message: '`Dead catch - ReflectionException is never thrown in the try block`'
+    -
+      path:       'src/TestTools.php'
+      identifier: 'method.dynamicName'
+      count:      1

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,20 @@
 <?xml version="1.0"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.2/phpunit.xsd"
         backupGlobals="true"
         colors="true"
-        displayDetailsOnTestsThatTriggerErrors="true"
-        displayDetailsOnTestsThatTriggerWarnings="true"
-        displayDetailsOnTestsThatTriggerNotices="true"
-        displayDetailsOnTestsThatTriggerDeprecations="true"
-        displayDetailsOnSkippedTests="true"
-        displayDetailsOnIncompleteTests="true"
         failOnEmptyTestSuite="true"
         failOnIncomplete="true"
         failOnRisky="true"
         failOnWarning="true"
-        processIsolation="false"
-        stopOnError="false"
-        stopOnFailure="false"
-        stopOnIncomplete="false"
-        stopOnSkipped="false"
-        stopOnRisky="false"
-        timeoutForSmallTests="1"
-        timeoutForMediumTests="10"
-        timeoutForLargeTests="60"
-        cacheDirectory="./build/.phpunit.cache"
-        backupStaticProperties="false"
-        requireCoverageMetadata="false">
+        displayDetailsOnTestsThatTriggerDeprecations="true"
+        displayDetailsOnPhpunitDeprecations="true"
+        displayDetailsOnTestsThatTriggerErrors="true"
+        displayDetailsOnTestsThatTriggerNotices="true"
+        displayDetailsOnTestsThatTriggerWarnings="true"
+        cacheDirectory="build/.phpunit.cache">
+
     <php>
         <ini name="error_reporting" value="E_ALL"/>
     </php>

--- a/src/AbstractTestCase.php
+++ b/src/AbstractTestCase.php
@@ -23,8 +23,8 @@ abstract class AbstractTestCase extends TestCase
         prophesize as parentProphesize;
     }
 
-    public const DEFAULT_PROPHECY = 0;
-    public const DUMMY_PROPHECY = 1;
+    public const int DEFAULT_PROPHECY = 0;
+    public const int DUMMY_PROPHECY = 1;
 
     /**
      * Every ObjectProphecy is considered to be a mock here
@@ -65,7 +65,7 @@ abstract class AbstractTestCase extends TestCase
     protected function getProphecyMethod(
         string $prophecyName,
         string $methodName,
-        array|null $arguments = null
+        array|null $arguments = null,
     ): MethodProphecy {
         return TestTools::getProphecyMethod($this->getProphecy($prophecyName), $methodName, $arguments);
     }
@@ -76,16 +76,16 @@ abstract class AbstractTestCase extends TestCase
      *
      * Methods behavior can still be changed later on, though.
      *
-     * @param class-string<T> $class
+     * @param class-string<T> $classOrInterface
      * @param int $prophecyDummyType
      * @return ObjectProphecy<T>
      * @throws \ReflectionException
      */
-    protected function prophesize(string $class, int $prophecyDummyType = self::DEFAULT_PROPHECY): ObjectProphecy
+    protected function prophesize(string $classOrInterface, int $prophecyDummyType = self::DEFAULT_PROPHECY): ObjectProphecy
     {
         return $prophecyDummyType === self::DUMMY_PROPHECY
-            ? $this->parentProphesize($class)
-            : $this->prophesizeDummy($class);
+            ? $this->parentProphesize($classOrInterface)
+            : $this->prophesizeDummy($classOrInterface);
     }
 
     /**

--- a/src/TestTools.php
+++ b/src/TestTools.php
@@ -67,7 +67,7 @@ class TestTools
         ObjectProphecy $prophecy,
         string|null $methodName,
         array|null $arguments = null,
-        mixed $return = null
+        mixed $return = null,
     ): MethodProphecy {
         if ($arguments === null) {
             $arguments = [Argument::cetera()];
@@ -121,7 +121,7 @@ class TestTools
     {
         if (($prophesizedObject instanceof ObjectProphecy) === false) {
             throw new \InvalidArgumentException(
-                'Expecting array of ObjectProphecy, got an instance of ' . $prophesizedObject::class . ' instead.'
+                'Expecting array of ObjectProphecy, got an instance of ' . $prophesizedObject::class . ' instead.',
             );
         }
     }

--- a/tests/ClassTestCaseTest.php
+++ b/tests/ClassTestCaseTest.php
@@ -34,7 +34,7 @@ class ClassTestCaseTest extends TestCase
             'sameInterface' => SomeInterface::class,
             ['someArray', 'withValues'],
             'a string',
-            SomeInterface::class => ClassTestCase::STRING_PARAMETER
+            SomeInterface::class => ClassTestCase::STRING_PARAMETER,
         ]);
 
 
@@ -42,13 +42,13 @@ class ClassTestCaseTest extends TestCase
 
         $testedClass = $mockClassTestCase->getTestedClass();
 
-        $this->assertInstanceOf(SomeInterface::class, $testedClass->interface);
-        $this->assertInstanceOf(ProphecySubjectInterface::class, $testedClass->interface);
-        $this->assertInstanceOf(SomeInterface::class, $testedClass->sameInterface);
-        $this->assertInstanceOf(ProphecySubjectInterface::class, $testedClass->sameInterface);
-        $this->assertNotSame($testedClass->interface, $testedClass->sameInterface);
-        $this->assertEquals(['someArray', 'withValues'], $testedClass->array);
-        $this->assertEquals('a string', $testedClass->someString);
-        $this->assertEquals(SomeInterface::class, $testedClass->someStringClass);
+        self::assertInstanceOf(SomeInterface::class, $testedClass->interface);
+        self::assertInstanceOf(ProphecySubjectInterface::class, $testedClass->interface);
+        self::assertInstanceOf(SomeInterface::class, $testedClass->sameInterface);
+        self::assertInstanceOf(ProphecySubjectInterface::class, $testedClass->sameInterface);
+        self::assertNotSame($testedClass->interface, $testedClass->sameInterface);
+        self::assertEquals(['someArray', 'withValues'], $testedClass->array);
+        self::assertEquals('a string', $testedClass->someString);
+        self::assertEquals(SomeInterface::class, $testedClass->someStringClass);
     }
 }

--- a/tests/TestClasses/SomeClass.php
+++ b/tests/TestClasses/SomeClass.php
@@ -17,6 +17,6 @@ class SomeClass
         public readonly SomeInterface $sameInterface,
         public readonly array $array,
         public readonly string $someString,
-        public readonly string $someStringClass
+        public readonly string $someStringClass,
     ) {}
 }


### PR DESCRIPTION
- Add support of PHP 8.4
- Add support of PHPUnit 11 & 12
- Drop support of PHP 8.1 & 8.2
- Drop support of PHPUnit 9
- Update CI configs
- Fix phpstan errors